### PR TITLE
XRT-1216: Updated modbus Readme to match other updated services

### DIFF
--- a/DeviceServices/modbus/README.md
+++ b/DeviceServices/modbus/README.md
@@ -1,55 +1,61 @@
 # XRT Config Examples
 
-This document is to help you run the example XRT configs provided which will allow
-you to communicate with a Modbus simulator via TCP or RTU. 
+## Overview
 
-First, navigate to `src/c/examples/xrt-examples/DeviceServices`
+This page shows you how to setup and run the Modbus-TCP device service example.
 
-## Modbus
+For more information about the Device Service please review the [Modbus Device Service](https://www.link.to.modbus.device.service.docs) documentation.
 
-This guide is for the `modbus` configuration using the profile for Network Power Meter - this profile can be found in the file `modbus-sim-profile.json`
+## Getting Started
 
-Start a modbus simulator:
-```
-docker run --rm -p 1502:1502 --name=modbus-simulator iotechsys/dev-testing-edgex-modbus-simulator:2.0.0
-```
+### **Run the simulator**
 
-Note that another modbus simulator may be used (e.g. ModbusPal) and may offer more extensive configuration. So long as the simulator and the device service go via the same port (for TCP) when making/receiving requests, the functionality should be consistent. If you want a value that fluctuates to repeatedly fetch, we recommend setting up a device and tying it to a linear generator in ModbusPal; see [this page for an example set-up of a Simulator)](https://plc4x.apache.org/users/getting-started/virtual-modbus.html).
+*For more information about the Modbus device simulator, see [Modbus Simulator](https://www.fixthislink.please).*
 
-Ensure that the register addresses being requested are available in the simulator; this can be specified in ModbusPal by pressing the eye icon next to the chosen device, and all registers up to 60,000 are available in the IoTech modbus simulator. The data addresses used by this example can be found in `modbus-sim-profile.json`. 
-
-Find out the IP address of the server:
-```
-$ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' modbus-simulator
+```bash
+./commands/start_device_sim.sh
 ```
 
-### Set Environment Variables for XRT
+### **Set Environment Variables**
 
-The XRT user guide provides instructions on how to simply install XRT as a package, or it can be cloned from the repository and built manually.
+We have provided a script to easily set these environment variables. Run:
+```bash
+. ./commands/set_env_vars.sh
+```
+*Note the dot before the path to the script, which is required to set the environment variables in the executing shell.*
 
-An environment variable pointing towards the location of the IoTech license will need set to run the Modbus device service:
+<!--todo: update-->
+**To set them manually:**
 
 - `MODBUS_DEVICE_ADDRESS`
-  - This variable contains the IP or serial address of the target modbus device. This could be a simulator or a physical device that supports modbus. This environment variable is used to update `devices.json` in the `state` directory of the example configs - without it, the device service won't be able to find the target modbus device. 
+    - This variable contains the IP or serial address of the target modbus device. This could be a simulator or a physical device that supports modbus. This environment variable is used to update `devices.json` in the `state` directory of the example configs - without it, the device service won't be able to find the target modbus device.
+      - Example for a locally-hosted Modbus TCP simulator: `export MODBUS_DEVICE_ADDRESS=127.0.0.1`
+      - Example for a locally-hosted Modbus RTU simulator: `export MODBUS_DEVICE_ADDRESS=/dev/tty/usb0`
+      - Example for Modbus TCP device hosted at another IP address: `export MODBUS_DEVICE_ADDRESS=192.168.10.100`
 
-  - Example for a locally-hosted Modbus TCP simulator: `export MODBUS_DEVICE_ADDRESS=127.0.0.1`
-  - Example for a locally-hosted Modbus RTU simulator: `export MODBUS_DEVICE_ADDRESS=/dev/tty/usb0`
-  - Example for Modbus TCP device hosted at another IP address: `export MODBUS_DEVICE_ADDRESS=192.168.10.100`
+
 
 - `MODBUS_DEVICE_PORT`
-    - This is an environment variable denoting the port used by the target modbus device.
-    - It is typically port 502 or 1502 if running a simulated device, although any available port will work with ModbusPal when configured through the GUI
+  - This is an environment variable denoting the port used by the target modbus device.
+  - It is typically port 502 or 1502 if running a simulated device, although any available port will work with ModbusPal when configured through the GUI. 
+    - Example: `export MODBUS_DEVICE_PORT=1502`
 
 An explanation for the setting of common device service environment variables can be found [here](../interactive-walkthrough/ds-getting-started-common.md#Device-service-configuration-setup).
 
-### Run XRT
+### **Common Device Service Setup**
 
-```
-$ xrt deployment/config
-```
+Follow [Device Service Example Getting Started](../interactive-walkthrough/ds-getting-started-common.md) for the common device service example setup steps.
 
-where 'xrt' is the shared library outputted following a build of XRT. 
-If done correctly, this will start a loop in which readings are obtained over regular intervals from registers specified in the profile. Note that the values returned from the simulator will be default '0' readings, unless updated in the simulator via a GUI like the one bundled with ModbusPal. 
+<!--todo: consider whether the below should be used with rtu AND tcp (i.e. in 2 separate folders)-->
+
+### **Run XRT with the config folder:**
+
+See [Setup XRT](../interactive-walkthrough/setup-xrt.md)
+
+```bash
+cd modbus
+xrt deployment/config
+```
 
 ## Walkthrough
 

--- a/DeviceServices/modbus/commands/add_subscription.sh
+++ b/DeviceServices/modbus/commands/add_subscription.sh
@@ -6,7 +6,7 @@ mosquitto_pub -t xrt/devices/modbus/request -m \
   "request_id": "1050",
   "op": "schedule:add",
   "schedule": {
-    "name":"modbus-sim-subscription1",
+    "name":"modbus-sim-schedule",
     "device":"modbus-sim",
     "resource":["Current"],
     "interval": 1000000,

--- a/DeviceServices/modbus/deployment/state/schedules.json
+++ b/DeviceServices/modbus/deployment/state/schedules.json
@@ -1,1 +1,15 @@
-{"modbus-sim-subscription1":{"device":"modbus-sim","interval":1000000,"name":"modbus-sim-subscription1","options":{"Subscription":{"Interval":0}},"resource":["Current"]}}
+{
+  "modbus-sim-schedule": {
+    "device": "modbus-sim",
+    "interval": 1000000,
+    "name": "modbus-sim-schedule",
+    "options": {
+      "Subscription": {
+        "Interval": 0
+      }
+    },
+    "resource": [
+      "Current"
+    ]
+  }
+}


### PR DESCRIPTION
Updated readme.md for modbus example so that it now matches bacnet and opc-ua in structure.