### PR TITLE
XRT-1343: updated device service examples

### DIFF
--- a/DeviceServices/bacnet-ip/commands/add_device.sh
+++ b/DeviceServices/bacnet-ip/commands/add_device.sh
@@ -10,7 +10,7 @@ mosquitto_pub -t xrt/devices/bacnet_ip/request -m \
     "profileName": "bacnet-ip-sim-profile",
     "protocols":{
       "BACnet-IP":{
-        "DeviceInstance": "1234"
+        "DeviceInstance": 1234
       }
     }
   }

--- a/DeviceServices/bacnet-ip/commands/add_discovered_device.sh
+++ b/DeviceServices/bacnet-ip/commands/add_discovered_device.sh
@@ -9,7 +9,7 @@ mosquitto_pub -t xrt/devices/bacnet_ip/request -m \
   "device_info":  {
     "protocols":{
       "BACnet-IP":{
-        "DeviceInstance": "1234"
+        "DeviceInstance": 1234
       }
     }
   }

--- a/DeviceServices/bacnet-ip/commands/remove_device_profile.sh
+++ b/DeviceServices/bacnet-ip/commands/remove_device_profile.sh
@@ -5,5 +5,5 @@ mosquitto_pub -t xrt/devices/bacnet_ip/request -m \
   "client": "example",
   "request_id": "1012",
   "op": "profile:delete",
-  "profile": "bacnet-ip-sim-profile"
+  "profileName": "bacnet-ip-sim-profile"
 }'

--- a/DeviceServices/bacnet-ip/deployment/profiles/bacnet-ip-sim-profile.json
+++ b/DeviceServices/bacnet-ip/deployment/profiles/bacnet-ip-sim-profile.json
@@ -144,7 +144,7 @@
       "name": "BacnetSimulator:protocol-services-supported",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -156,7 +156,7 @@
       "name": "BacnetSimulator:protocol-object-types-supported",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -229,7 +229,7 @@
       "name": "BacnetSimulator:device-address-binding",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -326,7 +326,7 @@
       "name": "BacnetSimulator:active-cov-subscriptions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -339,7 +339,7 @@
       "name": "BacnetSimulator:time-synchronization-recipients",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -435,7 +435,7 @@
       "name": "analog_input_0:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -579,7 +579,7 @@
       "name": "analog_input_0:limit-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -591,7 +591,7 @@
       "name": "analog_input_0:event-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -603,7 +603,7 @@
       "name": "analog_input_0:acked-transitions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -628,7 +628,7 @@
       "name": "analog_input_0:event-time-stamps",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -724,7 +724,7 @@
       "name": "analog_input_1:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -868,7 +868,7 @@
       "name": "analog_input_1:limit-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -880,7 +880,7 @@
       "name": "analog_input_1:event-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -892,7 +892,7 @@
       "name": "analog_input_1:acked-transitions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -917,7 +917,7 @@
       "name": "analog_input_1:event-time-stamps",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1013,7 +1013,7 @@
       "name": "analog_output_0:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1133,7 +1133,7 @@
       "name": "analog_output_1:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1253,7 +1253,7 @@
       "name": "analog_value_0:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1385,7 +1385,7 @@
       "name": "analog_value_0:limit-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1397,7 +1397,7 @@
       "name": "analog_value_0:event-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1409,7 +1409,7 @@
       "name": "analog_value_0:acked-transitions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1434,7 +1434,7 @@
       "name": "analog_value_0:event-time-stamps",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1494,7 +1494,7 @@
       "name": "analog_value_1:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1626,7 +1626,7 @@
       "name": "analog_value_1:limit-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1638,7 +1638,7 @@
       "name": "analog_value_1:event-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1650,7 +1650,7 @@
       "name": "analog_value_1:acked-transitions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1675,7 +1675,7 @@
       "name": "analog_value_1:event-time-stamps",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     }
   ]

--- a/DeviceServices/bacnet-mstp/commands/add_device.sh
+++ b/DeviceServices/bacnet-mstp/commands/add_device.sh
@@ -10,7 +10,7 @@ mosquitto_pub -t xrt/devices/bacnet_mstp/request -m \
     "profileName": "bacnet-mstp-sim-profile",
     "protocols":{
       "BACnet-MSTP":{
-        "DeviceInstance": "1234"
+        "DeviceInstance": 1234
       }
     }
   }

--- a/DeviceServices/bacnet-mstp/commands/add_discovered_device.sh
+++ b/DeviceServices/bacnet-mstp/commands/add_discovered_device.sh
@@ -9,7 +9,7 @@ mosquitto_pub -t xrt/devices/bacnet_mstp/request -m \
   "device_info":  {
     "protocols":{
       "BACnet-MSTP":{
-        "DeviceInstance": "1234"
+        "DeviceInstance": 1234
       }
     }
   }

--- a/DeviceServices/bacnet-mstp/commands/remove_device_profile.sh
+++ b/DeviceServices/bacnet-mstp/commands/remove_device_profile.sh
@@ -5,5 +5,5 @@ mosquitto_pub -t xrt/devices/bacnet_mstp/request -m \
   "client": "example",
   "request_id": "1012",
   "op": "profile:delete",
-  "profile": "bacnet-mstp-sim-profile"
+  "profileName": "bacnet-mstp-sim-profile"
 }'

--- a/DeviceServices/bacnet-mstp/deployment/profiles/bacnet-mstp-sim-profile.json
+++ b/DeviceServices/bacnet-mstp/deployment/profiles/bacnet-mstp-sim-profile.json
@@ -144,7 +144,7 @@
       "name": "BacnetSimulator:protocol-services-supported",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -156,7 +156,7 @@
       "name": "BacnetSimulator:protocol-object-types-supported",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -229,7 +229,7 @@
       "name": "BacnetSimulator:device-address-binding",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -326,7 +326,7 @@
       "name": "BacnetSimulator:active-cov-subscriptions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -339,7 +339,7 @@
       "name": "BacnetSimulator:time-synchronization-recipients",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -435,7 +435,7 @@
       "name": "analog_input_0:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -579,7 +579,7 @@
       "name": "analog_input_0:limit-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -591,7 +591,7 @@
       "name": "analog_input_0:event-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -603,7 +603,7 @@
       "name": "analog_input_0:acked-transitions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -628,7 +628,7 @@
       "name": "analog_input_0:event-time-stamps",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -724,7 +724,7 @@
       "name": "analog_input_1:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -868,7 +868,7 @@
       "name": "analog_input_1:limit-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -880,7 +880,7 @@
       "name": "analog_input_1:event-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -892,7 +892,7 @@
       "name": "analog_input_1:acked-transitions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -917,7 +917,7 @@
       "name": "analog_input_1:event-time-stamps",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1013,7 +1013,7 @@
       "name": "analog_output_0:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1133,7 +1133,7 @@
       "name": "analog_output_1:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1253,7 +1253,7 @@
       "name": "analog_value_0:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1385,7 +1385,7 @@
       "name": "analog_value_0:limit-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1397,7 +1397,7 @@
       "name": "analog_value_0:event-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1409,7 +1409,7 @@
       "name": "analog_value_0:acked-transitions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1434,7 +1434,7 @@
       "name": "analog_value_0:event-time-stamps",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1494,7 +1494,7 @@
       "name": "analog_value_1:status-flags",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1626,7 +1626,7 @@
       "name": "analog_value_1:limit-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1638,7 +1638,7 @@
       "name": "analog_value_1:event-enable",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1650,7 +1650,7 @@
       "name": "analog_value_1:acked-transitions",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     },
     {
@@ -1675,7 +1675,7 @@
       "name": "analog_value_1:event-time-stamps",
       "properties": {
         "readWrite": "RW",
-        "valueType": "binary"
+        "valueType": "uint8array"
       }
     }
   ]

--- a/DeviceServices/ble/deployment/state/devices.json
+++ b/DeviceServices/ble/deployment/state/devices.json
@@ -1,7 +1,7 @@
 {
   "ble-sim" : {
     "name": "ble-sim",
-    "profile" : "ble-sim-profile",
+    "profileName" : "ble-sim-profile",
     "protocols": {
       "BLE": {
         "MAC": "00:AA:01:01:00:24"

--- a/DeviceServices/ethercat/deployment/state/devices.json
+++ b/DeviceServices/ethercat/deployment/state/devices.json
@@ -1,7 +1,7 @@
 {
   "EK1100":{
     "name":"EK1100",
-    "profile":"EK1100",
+    "profileName":"EK1100",
     "protocols":{
       "EtherCAT":{
         "NetworkIndex":1,
@@ -11,7 +11,7 @@
   },
   "EL7037":{
     "name":"EL7037",
-    "profile":"EL7037-VelocityDirect",
+    "profileName":"EL7037-VelocityDirect",
     "protocols":{
       "EtherCAT":{
         "NetworkIndex":2,
@@ -21,7 +21,7 @@
   },
   "XMC4800":{
     "name":"XMC4800",
-    "profile":"XMC4800_V3_1",
+    "profileName":"XMC4800_V3_1",
     "protocols":{
       "EtherCAT":{
         "NetworkIndex":3,

--- a/DeviceServices/ethernet-ip/commands/remove_device_profile.sh
+++ b/DeviceServices/ethernet-ip/commands/remove_device_profile.sh
@@ -5,5 +5,5 @@ mosquitto_pub -t xrt/devices/ethernet_ip/request -m \
   "client": "example",
   "request_id":"1012",
   "op": "profile:delete",
-  "profile": "ethernetip-sim-profile"
+  "profileName": "ethernetip-sim-profile"
 }'

--- a/DeviceServices/ethernet-ip/deployment/state/devices.json
+++ b/DeviceServices/ethernet-ip/deployment/state/devices.json
@@ -1,7 +1,7 @@
 {
   "ethernetip-sim": {
     "name": "ethernetip-sim",
-    "profile": "ethernetip-sim-profile",
+    "profileName": "ethernetip-sim-profile",
     "protocols": {
       "IP": {
         "Address": "${ETHERNETIP_SIM_ADDRESS}"

--- a/DeviceServices/opc-ua/deployment/state/devices.json
+++ b/DeviceServices/opc-ua/deployment/state/devices.json
@@ -1,7 +1,7 @@
 {
   "LDS": {
     "name": "LDS",
-    "profile": "LDS_profile",
+    "profileName": "LDS_profile",
     "protocols": {
       "OPC-UA": {
         "Address": "${OPCUA_LDS_ADDRESS}",
@@ -11,7 +11,7 @@
   },
   "opc-ua-sim": {
     "name": "opc-ua-sim",
-    "profile": "opc-ua-sim-profile",
+    "profileName": "opc-ua-sim-profile",
     "protocols": {
       "OPC-UA": {
         "Address": "${OPCUA_SIM_ADDRESS}",

--- a/DeviceServices/s7/deployment/state/devices.json
+++ b/DeviceServices/s7/deployment/state/devices.json
@@ -1,6 +1,6 @@
 {
   "S7-Server": {
-    "profile": "Server",
+    "profileName": "Server",
     "protocols": {
       "S7": {
         "IP": "${S7_SIM_ADDRESS}",


### PR DESCRIPTION
- Fixed bacnet protocol property that should have been an integer
- Fixed usage of profile to profileName, XRT is compatible with both so worked before hand anyway
- Now there proper support of uint8arrays, bacnet raw types have been updated to use them instead of binary