### PR TITLE
XRT-1453: Updated simulator references

### DIFF
--- a/DeviceServices/modbus-rtu/commands/rtu-sim.sh
+++ b/DeviceServices/modbus-rtu/commands/rtu-sim.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-socat -d -d -d -d pty,link=/tmp/master,raw,echo=0 pty,link=/tmp/slave,raw,echo=0 &
-sleep 1
-socat tcp-listen:50103,reuseaddr,fork file:/tmp/slave,nonblock,raw,echo=0 &
-sleep 1
-
-./modbus-simulator -protocol=RTU

--- a/DeviceServices/modbus-rtu/commands/start_device_sim.sh
+++ b/DeviceServices/modbus-rtu/commands/start_device_sim.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker run --rm -d -v $PWD/commands/rtu-sim.sh:/rtu-sim.sh --entrypoint /rtu-sim.sh --name modbus-sim iotechsys/dev-testing-edgex-modbus-simulator:2.0.0
+docker run --rm -d -e RUN_MODE=RTU --name modbus-sim iotechsys/modbus-sim:1.0.1
 sleep 4
 MODBUS_SIM_ADDRESS=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' modbus-sim)
 (socat pty,link=/tmp/virtualport,raw,echo=0 tcp:${MODBUS_SIM_ADDRESS}:50103) &

--- a/DeviceServices/modbus-tcp/commands/start_device_sim.sh
+++ b/DeviceServices/modbus-tcp/commands/start_device_sim.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-docker run --rm -d --name modbus-sim -p 1502 iotechsys/dev-testing-edgex-modbus-simulator:2.0.0
+docker run --rm -d --name modbus-sim iotechsys/modbus-sim:1.0.1
 


### PR DESCRIPTION
Updated references in modbus examples files to refer to the new simulator repository, as opposed to drawing from the modbus-go repository as it was previously. Still needs tested so leaving without a reviewer until then.