### PR TITLE
XRT-1625: update protocol property environment variable usage

### DIFF
--- a/DeviceServices/ethernet-ip/commands/add_device.sh
+++ b/DeviceServices/ethernet-ip/commands/add_device.sh
@@ -1,30 +1,30 @@
 #!/bin/sh
 
 mosquitto_pub -t xrt/devices/ethernet_ip/request -m \
-'{
-  "client": "example",
-  "request_id":"1010",
-  "op": "device:add",
-  "type": "xrt.request:1.0",
-  "device": "ethernetip-sim",
-  "device_info":{
-    "profileName": "ethernetip-sim-profile",
-    "protocols":{
-        "EtherNet-IP":{
-            "Address": "${ETHERNETIP_SIM_ADDRESS}",
-            "O2T":{
-                "ConnectionType": "p2p",
-                "RPI": 10,
-                "Priority": "low",
-                "Ownership": "exclusive"
+"{
+  \"client\": \"example\",
+  \"request_id\":\"1010\",
+  \"op\": \"device:add\",
+  \"type\": \"xrt.request:1.0\",
+  \"device\": \"ethernetip-sim\",
+  \"device_info\":{
+    \"profileName\": \"ethernetip-sim-profile\",
+    \"protocols\":{
+        \"EtherNet-IP\":{
+            \"Address\": \"$ETHERNETIP_SIM_ADDRESS\",
+            \"O2T\":{
+                \"ConnectionType\": \"p2p\",
+                \"RPI\": 10,
+                \"Priority\": \"low\",
+                \"Ownership\": \"exclusive\"
                 },
-            "T2O": {
-                "ConnectionType": "p2p",
-                "RPI": 10,
-                "Priority": "low",
-                "Ownership": "exclusive"
+            \"T2O\": {
+                \"ConnectionType\": \"p2p\",
+                \"RPI\": 10,
+                \"Priority\": \"low\",
+                \"Ownership\": \"exclusive\"
                 }
             }
         }
     }
-}'
+}"

--- a/DeviceServices/ethernet-ip/commands/start_device_sim.sh
+++ b/DeviceServices/ethernet-ip/commands/start_device_sim.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker run -i --rm --name=ethernetip-sim  iotechsys/ethernetip-sim:1.0
+docker run -i -d --rm --name=ethernetip-sim  iotechsys/ethernetip-sim:1.0

--- a/DeviceServices/modbus-tcp/commands/add_device.sh
+++ b/DeviceServices/modbus-tcp/commands/add_device.sh
@@ -1,20 +1,20 @@
 #!/bin/sh
 
 mosquitto_pub -t xrt/devices/modbus/request -m \
-'{
-  "client": "example",
-  "request_id":"1010",
-  "op": "device:add",
-  "type": "xrt.request:1.0",
-  "device": "modbus-sim",
-  "device_info":  {
-    "profileName": "modbus-sim-profile",
-    "protocols":{
-      'modbus-tcp':{
-        "Address": "${MODBUS_SIM_ADDRESS}",
-        "Port": 1502,
-        "UnitID": 1
+"{
+  \"client\": \"example\",
+  \"request_id\":\"1010\",
+  \"op\": \"device:add\",
+  \"type\": \"xrt.request:1.0\",
+  \"device\": \"modbus-sim\",
+  \"device_info\":  {
+    \"profileName\": \"modbus-sim-profile\",
+    \"protocols\":{
+      \"modbus-tcp\":{
+        \"Address\": \"$MODBUS_SIM_ADDRESS\",
+        \"Port\": 1502,
+        \"UnitID\": 1
       }
     }
   }
-}'
+}"


### PR DESCRIPTION
These changes allow the add_device.sh scripts for modbus tcp and ethernet-ip to evaluate the IP address environment variables of the simulators

Also added the detach flag to the start_sim script of ethernet-ip. This allows the script to run the sim in the background

Tested these new scripts and they work as expected