### PR TITLE
XRT-1644: Added square brackets around resources in add_schedule.sh

### DIFF
--- a/DeviceServices/modbus-rtu/commands/add_schedule.sh
+++ b/DeviceServices/modbus-rtu/commands/add_schedule.sh
@@ -9,7 +9,7 @@ mosquitto_pub -t xrt/devices/modbus/request -m \
   "schedule": {
     "name":"modbus-example-schedule1",
     "device":"modbus-sim",
-    "resource":"Current",
+    "resource": ["Current"],
     "interval": 1000000
   }
 }'

--- a/DeviceServices/modbus-tcp/commands/add_schedule.sh
+++ b/DeviceServices/modbus-tcp/commands/add_schedule.sh
@@ -9,7 +9,7 @@ mosquitto_pub -t xrt/devices/modbus/request -m \
   "schedule": {
     "name":"modbus-example-schedule1",
     "device":"modbus-sim",
-    "resource":"Current",
+    "resource": ["Current"],
     "interval": 1000000
   }
 }'


### PR DESCRIPTION
Added due to bug in schedule validation where schedule resources loaded on boot won't be run unless resources are enclosed in square brackets but can still be added. 