### PR TITLE
XRT-1900: Update mqtt config - KeepAliveInterval and RetryInterval

### DIFF
--- a/ApplicationComponent/deployment/config/mqtt_bridge.json
+++ b/ApplicationComponent/deployment/config/mqtt_bridge.json
@@ -9,7 +9,7 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 0,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
       "ConnectTimeout": 0,

--- a/Bridge/mqtt/pub/deployment/config/bridgepub.json
+++ b/Bridge/mqtt/pub/deployment/config/bridgepub.json
@@ -10,7 +10,7 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 30,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
       "ConnectTimeout": 0,

--- a/Bridge/mqtt/sub/deployment/config/bridgesub.json
+++ b/Bridge/mqtt/sub/deployment/config/bridgesub.json
@@ -10,7 +10,7 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 30,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
       "ConnectTimeout": 0,

--- a/CommandComponent/deployment/config/mqtt_bridge.json
+++ b/CommandComponent/deployment/config/mqtt_bridge.json
@@ -18,14 +18,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/bacnet-ip/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/bacnet-ip/deployment/config/mqtt_bridge.json
@@ -14,14 +14,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/bacnet-mstp/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/bacnet-mstp/deployment/config/mqtt_bridge.json
@@ -14,14 +14,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/ble/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/ble/deployment/config/mqtt_bridge.json
@@ -14,14 +14,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/ethercat/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/ethercat/deployment/config/mqtt_bridge.json
@@ -13,14 +13,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/ethernet-ip/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/ethernet-ip/deployment/config/mqtt_bridge.json
@@ -13,13 +13,12 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval":60,
       "MQTTVersion": 5,
       "Username": "${XRT_MQTT_USERNAME}",
-      "Password": "${XRT_MQTT_PASSWORD}"
+      "Password": "${XRT_MQTT_PASSWORD}",
+      "RetryInterval": 5
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/gps/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/gps/deployment/config/mqtt_bridge.json
@@ -8,19 +8,18 @@
   "MQTTPatterns": [ "xrt/devices/gps/request" ],
   "MQTTConfig":
   {
-    	"ServerURI": "${XRT_MQTT_BROKER}",
-    	"ClientID": "xrt",
-    	"QoS": 1,
-    	"ClientConfig": 
-    	{
-    	"Username":"${XRT_MQTT_USERNAME}",
-    	"Password": "${XRT_MQTT_PASSWORD}", 
-    	"KeepAliveInterval": 10,
-    	"MQTTVersion": 5,
-    	"Reliable": true
-     },
-    "RetryCount": 5,
-    "RetryInterval": 5
+    "ServerURI": "${XRT_MQTT_BROKER}",
+    "ClientID": "xrt",
+    "QoS": 1,
+    "ClientConfig": 
+    {
+      "Username":"${XRT_MQTT_USERNAME}",
+      "Password": "${XRT_MQTT_PASSWORD}", 
+      "KeepAliveInterval": 60,
+      "MQTTVersion": 5,
+      "Reliable": true,
+      "RetryInterval": 5
+    },
   },
   "Cookie": 125,
   "Bus": "bus",

--- a/DeviceServices/modbus-rtu/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/modbus-rtu/deployment/config/mqtt_bridge.json
@@ -14,14 +14,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/modbus-tcp/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/modbus-tcp/deployment/config/mqtt_bridge.json
@@ -14,14 +14,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/opc-ua/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/opc-ua/deployment/config/mqtt_bridge.json
@@ -14,14 +14,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/profinet/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/profinet/deployment/config/mqtt_bridge.json
@@ -13,14 +13,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/DeviceServices/s7/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/s7/deployment/config/mqtt_bridge.json
@@ -8,19 +8,18 @@
   "MQTTPatterns": [ "xrt/devices/s7/request" ],
   "MQTTConfig":
   {
-    	"ServerURI": "${XRT_MQTT_BROKER}",
-    	"ClientID": "xrt",
-    	"QoS": 1,
-    	"ClientConfig": 
-    	{
-    	"Username":"${XRT_MQTT_USERNAME}",
-    	"Password": "${XRT_MQTT_PASSWORD}", 
-    	"KeepAliveInterval": 10,
-    	"MQTTVersion": 5,
-    	"Reliable": true
-     },
-    "RetryCount": 5,
-    "RetryInterval": 5
+    "ServerURI": "${XRT_MQTT_BROKER}",
+    "ClientID": "xrt",
+    "QoS": 1,
+    "ClientConfig": 
+    {
+      "Username":"${XRT_MQTT_USERNAME}",
+      "Password": "${XRT_MQTT_PASSWORD}", 
+      "KeepAliveInterval": 60,
+      "MQTTVersion": 5,
+      "Reliable": true,
+      "RetryInterval": 5
+    },
   },
   "Cookie": 125,
   "Bus": "bus",

--- a/DeviceServices/virtual/deployment/config/mqtt_bridge.json
+++ b/DeviceServices/virtual/deployment/config/mqtt_bridge.json
@@ -14,14 +14,13 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 5,
       "Reliable": true,
+      "RetryInterval": 5,
       "Username": "${XRT_MQTT_USERNAME}",
       "Password": "${XRT_MQTT_PASSWORD}"
     },
-    "RetryCount": 5,
-    "RetryInterval": 5
   },
   "Cookie": 125,
   "QueueSize": 5,

--- a/Exporters/mqtt/aws/deployment/config/export_aws.json
+++ b/Exporters/mqtt/aws/deployment/config/export_aws.json
@@ -9,7 +9,7 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 4,
       "Reliable": true,
       "ConnectTimeout": 30,

--- a/Exporters/mqtt/azure/deployment/config/export_azure.json
+++ b/Exporters/mqtt/azure/deployment/config/export_azure.json
@@ -14,7 +14,7 @@
     {
       "Username":"${AZURE_MQTT_USERNAME}",
       "Password": "${AZURE_MQTT_SAS_PASSWORD}",
-      "KeepAliveInterval": 10,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 4,
       "Reliable": true,
       "SSLConfig":
@@ -22,7 +22,6 @@
         "TrustStore":"${AZURE_MQTT_ROOT_CA}"
       }
     },
-    "RetryCount": 5,
     "RetryInterval": 5
   },
   "Cookie": 125,

--- a/Exporters/mqtt/mosquitto/deployment/config/mqtt_bridge.json
+++ b/Exporters/mqtt/mosquitto/deployment/config/mqtt_bridge.json
@@ -9,7 +9,7 @@
     "QoS": 1,
     "ClientConfig":
     {
-      "KeepAliveInterval": 0,
+      "KeepAliveInterval": 60,
       "MQTTVersion": 4,
       "Reliable": true,
       "ConnectTimeout": 0,


### PR DESCRIPTION
- KeepAliveInterval is set to 60 secs, which is recommended
- Update MQTT Config - RetryInterval is read as part of client config. Unused configuration variable Retrycount deleted.
