### PR TITLE
XRT-2035: Added zero address and scaling modbus examples

### DIFF
--- a/DeviceServices/modbus-rtu/deployment/profiles/modbus-sim-profile.json
+++ b/DeviceServices/modbus-rtu/deployment/profiles/modbus-sim-profile.json
@@ -81,6 +81,78 @@
         "valueType": "UINT16",
         "readWrite": "R"
       }
+    },
+    {
+      "name": "ExampleZeroStartingAddress",
+      "description": "Example resource. Accesses first address to demonstrate zero-based addressing",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 0
+      },
+      "properties": {
+        "valueType": "UINT16",
+        "readWrite": "RW"
+      }
+    },
+    {
+      "name": "ExampleRWScale0.1",
+      "description": "Example Float32 resource demonstrating RW scale factor 0.1",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 20,
+        "scaleType": "RW",
+        "scale": 0.1,
+        "rawType": "UINT16"
+      },
+      "properties": {
+        "valueType": "FLOAT32",
+        "readWrite": "RW"
+      }
+    },
+    {
+      "name": "ExampleRWScale0.001",
+      "description": "Example Float64 resource demonstrating RW scale factor 0.001",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 21,
+        "scaleType": "RW",
+        "scale": 0.001,
+        "rawType": "UINT16"
+      },
+      "properties": {
+        "valueType": "FLOAT64",
+        "readWrite": "RW"
+      }
+    },
+    {
+      "name": "ExampleWOnlyScale0.1",
+      "description": "Example Float64 resource demonstrating W-only scale factor 0.1",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 22,
+        "scaleType": "W",
+        "scale": 0.1,
+        "rawType": "UINT16"
+      },
+      "properties": {
+        "valueType": "FLOAT64",
+        "readWrite": "RW"
+      }
+    },
+    {
+      "name": "ExampleROnlyScale0.1",
+      "description": "Example Float64 resource demonstrating R-only scale factor 0.1",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 23,
+        "scaleType": "R",
+        "scale": 0.1,
+        "rawType": "UINT16"
+      },
+      "properties": {
+        "valueType": "FLOAT64",
+        "readWrite": "RW"
+      }
     }
   ]
 }

--- a/DeviceServices/modbus-rtu/deployment/profiles/modbus-sim-profile.json
+++ b/DeviceServices/modbus-rtu/deployment/profiles/modbus-sim-profile.json
@@ -84,7 +84,7 @@
     },
     {
       "name": "ExampleZeroStartingAddress",
-      "description": "Example resource. Accesses first address to demonstrate zero-based addressing",
+      "description": "Example UINT16 resource that does not belong to real device. Accesses first address to demonstrate zero-based addressing.",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 0
@@ -96,7 +96,7 @@
     },
     {
       "name": "ExampleRWScale0.1",
-      "description": "Example Float32 resource demonstrating RW scale factor 0.1",
+      "description": "Example Float32 resource that does not belong to real device. Demonstrates RW scale factor 0.1",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 20,
@@ -111,7 +111,7 @@
     },
     {
       "name": "ExampleRWScale0.001",
-      "description": "Example Float64 resource demonstrating RW scale factor 0.001",
+      "description": "Example Float64 resource that does not belong to real device. Demonstrates RW scale factor 0.001",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 21,
@@ -126,7 +126,7 @@
     },
     {
       "name": "ExampleWOnlyScale0.1",
-      "description": "Example Float64 resource demonstrating W-only scale factor 0.1",
+      "description": "EExample Float64 resource that does not belong to real device. Demonstrates W-only scale factor 0.1",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 22,
@@ -141,7 +141,7 @@
     },
     {
       "name": "ExampleROnlyScale0.1",
-      "description": "Example Float64 resource demonstrating R-only scale factor 0.1",
+      "description": "Example Float64 resource that does not belong to real device. Demonstrates R-only scale factor 0.1",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 23,

--- a/DeviceServices/modbus-rtu/deployment/profiles/modbus-sim-profile.json
+++ b/DeviceServices/modbus-rtu/deployment/profiles/modbus-sim-profile.json
@@ -126,7 +126,7 @@
     },
     {
       "name": "ExampleWOnlyScale0.1",
-      "description": "EExample Float64 resource that does not belong to real device. Demonstrates W-only scale factor 0.1",
+      "description": "Example Float64 resource that does not belong to real device. Demonstrates W-only scale factor 0.1",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 22,

--- a/DeviceServices/modbus-tcp/deployment/profiles/modbus-sim-profile.json
+++ b/DeviceServices/modbus-tcp/deployment/profiles/modbus-sim-profile.json
@@ -82,6 +82,78 @@
         "valueType": "UINT16",
         "readWrite": "R"
       }
+    },
+    {
+      "name": "ExampleZeroStartingAddress",
+      "description": "Example resource. Accesses first address to demonstrate zero-based addressing",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 0
+      },
+      "properties": {
+        "valueType": "UINT16",
+        "readWrite": "RW"
+      }
+    },
+    {
+      "name": "ExampleRWScale0.1",
+      "description": "Example Float32 resource demonstrating RW scale factor 0.1",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 20,
+        "scaleType": "RW",
+        "scale": 0.1,
+        "rawType": "UINT16"
+      },
+      "properties": {
+        "valueType": "FLOAT32",
+        "readWrite": "RW"
+      }
+    },
+    {
+      "name": "ExampleRWScale0.001",
+      "description": "Example Float64 resource demonstrating RW scale factor 0.001",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 21,
+        "scaleType": "RW",
+        "scale": 0.001,
+        "rawType": "UINT16"
+      },
+      "properties": {
+        "valueType": "FLOAT64",
+        "readWrite": "RW"
+      }
+    },
+    {
+      "name": "ExampleWOnlyScale0.1",
+      "description": "Example Float64 resource demonstrating W-only scale factor 0.1",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 22,
+        "scaleType": "W",
+        "scale": 0.1,
+        "rawType": "UINT16"
+      },
+      "properties": {
+        "valueType": "FLOAT64",
+        "readWrite": "RW"
+      }
+    },
+    {
+      "name": "ExampleROnlyScale0.1",
+      "description": "Example Float64 resource demonstrating R-only scale factor 0.1",
+      "attributes": {
+        "primaryTable": "HOLDING_REGISTERS",
+        "startingAddress": 23,
+        "scaleType": "R",
+        "scale": 0.1,
+        "rawType": "UINT16"
+      },
+      "properties": {
+        "valueType": "FLOAT64",
+        "readWrite": "RW"
+      }
     }
   ]
 }

--- a/DeviceServices/modbus-tcp/deployment/profiles/modbus-sim-profile.json
+++ b/DeviceServices/modbus-tcp/deployment/profiles/modbus-sim-profile.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "ExampleWOnlyScale0.1",
-      "description": "EExample Float64 resource that does not belong to real device. Demonstrates W-only scale factor 0.1",
+      "description": "Example Float64 resource that does not belong to real device. Demonstrates W-only scale factor 0.1",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 22,

--- a/DeviceServices/modbus-tcp/deployment/profiles/modbus-sim-profile.json
+++ b/DeviceServices/modbus-tcp/deployment/profiles/modbus-sim-profile.json
@@ -85,7 +85,7 @@
     },
     {
       "name": "ExampleZeroStartingAddress",
-      "description": "Example resource. Accesses first address to demonstrate zero-based addressing",
+      "description": "Example UINT16 resource that does not belong to real device. Accesses first address to demonstrate zero-based addressing.",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 0
@@ -97,7 +97,7 @@
     },
     {
       "name": "ExampleRWScale0.1",
-      "description": "Example Float32 resource demonstrating RW scale factor 0.1",
+      "description": "Example Float32 resource that does not belong to real device. Demonstrates RW scale factor 0.1",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 20,
@@ -112,7 +112,7 @@
     },
     {
       "name": "ExampleRWScale0.001",
-      "description": "Example Float64 resource demonstrating RW scale factor 0.001",
+      "description": "Example Float64 resource that does not belong to real device. Demonstrates RW scale factor 0.001",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 21,
@@ -127,7 +127,7 @@
     },
     {
       "name": "ExampleWOnlyScale0.1",
-      "description": "Example Float64 resource demonstrating W-only scale factor 0.1",
+      "description": "EExample Float64 resource that does not belong to real device. Demonstrates W-only scale factor 0.1",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 22,
@@ -142,7 +142,7 @@
     },
     {
       "name": "ExampleROnlyScale0.1",
-      "description": "Example Float64 resource demonstrating R-only scale factor 0.1",
+      "description": "Example Float64 resource that does not belong to real device. Demonstrates R-only scale factor 0.1",
       "attributes": {
         "primaryTable": "HOLDING_REGISTERS",
         "startingAddress": 23,


### PR DESCRIPTION
Existing Modbus example profile appears to be based off a real device. In each description of these new example resources, I have explained that they do not belong to the real device.