### PR TITLE
XRT-2739 fix: Update mqtt_bridge config to include command discovery …

### DIFF
--- a/CommandComponent/deployment/config/mqtt_bridge.json
+++ b/CommandComponent/deployment/config/mqtt_bridge.json
@@ -2,12 +2,14 @@
   "Library": "libxrt-mqtt-bridge.so",
   "Factory": "xrt_mqtt_bridge_factory",
   "Patterns": [
+    "xrt/command/discovery",
     "xrt/command/reply",
     "xrt/devices/virtual/telemetry",
     "xrt/devices/virtual/reply",
     "xrt/devices/virtual/discovery"
   ],
   "MQTTPatterns": [
+    "xrt/command/discovery",
     "xrt/command/request",
     "xrt/devices/virtual/request"
   ],

--- a/Servers/opc-ua/federated/deployment/config/mqtt_bridge.json
+++ b/Servers/opc-ua/federated/deployment/config/mqtt_bridge.json
@@ -3,6 +3,7 @@
   "Factory": "xrt_mqtt_bridge_factory",
   "Patterns": [ 
     "xrt/request",
+    "xrt/discovery",
     "+/devices/+/request"
   ],
   "MQTTPatterns": [ 


### PR DESCRIPTION
…topic required to support discovery:discover request

@edward-scott A point to note: There is always going to be an initial discovery message over mqtt when Xrt comes up.