### PR TITLE
XRT-3281 fix(tests): Add missing SPARKPLUG_APPS env var to script

### DIFF
--- a/set_env_vars.sh
+++ b/set_env_vars.sh
@@ -33,6 +33,7 @@ export SPARKPLUG_NODE1=xrt1
 export SPARKPLUG_NODE2=xrt2
 export SPARKPLUG_GROUP=iotech
 export SPARKPLUG_PROTO=spb
+export SPARKPLUG_APPS=""
 
 # Service Names
 export FILE_SERVICE=file


### PR DESCRIPTION
This adds the missing SPARKPLUG_APPS env variable to the setup script which stops it from throwing the following error
```
xrt_xform_apply: Failed to find xform: spb
```